### PR TITLE
chapter9 [ルーティング]

### DIFF
--- a/app/controllers/admin/base.rb
+++ b/app/controllers/admin/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Admin::Base < ApplicationController
 
   def current_administrator

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -34,7 +34,7 @@ class Admin::SessionsController < Admin::Base
 
   def destroy
     session.delete(:administrator_id)
-    flash[:notice] = "ログインアウトしました。"
+    flash[:notice] = "ログアウトしました。"
     redirect_to :admin_root
   end
 end

--- a/app/controllers/admin/top_controller.rb
+++ b/app/controllers/admin/top_controller.rb
@@ -1,6 +1,10 @@
 class Admin::TopController < Admin::Base
 
   def index
+    if current_administrator
+      render action: 'dashboard'
+    else
     render action: "index"
+    end
   end
 end

--- a/app/views/admin/top/dashboard.html.erb
+++ b/app/views/admin/top/dashboard.html.erb
@@ -1,0 +1,5 @@
+<% @title = 'ダッシュボード'%>
+
+<ul class='menu'>
+  <li><%= link_to '職員管理', :admin_staff_members %></li>
+</ul>

--- a/config/initializers/baukis2.rb
+++ b/config/initializers/baukis2.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.baukis2 = {
+    staff: { host: 'baukis2.example.com', path: '' },
+    admin: { host: 'baukis2.example.com', path: 'admin' },
+    customer: { host: 'example.com', path: 'mypage' }
+  }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,9 @@ Rails.application.routes.draw do
     end
   end
 
-  namespace :customer do
-    root "top#index"
+  constraints host: config[:customer][:host] do
+    namespace :customer, path: config[:customer][:path] do
+      root "top#index"
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,19 +1,23 @@
 Rails.application.routes.draw do
 
-  namespace :staff, path: '' do
-    root "top#index"
+  config = Rails.application.config.baukis2
 
-    get "/login" => "sessions#new"
-    resource :session, only: %i(create destroy)
-    resource :account, except: %i(new create destroy)
+  constraints host: config[:staff][:host] do
+    namespace :staff, path: config[:staff][:path] do
+      root "top#index"
+      get "/login" => "sessions#new"
+      resource :session, only: %i(create destroy)
+      resource :account, except: %i(new create destroy)
+    end
   end
 
-  namespace :admin do
-    root "top#index"
-
-    get "/login" => "sessions#new"
-    resource :session, only: %i(create destroy)
-    resources :staff_members
+  constraints host: config[:admin][:host] do
+    namespace :admin, path: config[:admin][:path] do
+      root "top#index"
+      get "/login" => "sessions#new"
+      resource :session, only: %i(create destroy)
+      resources :staff_members
+    end
   end
 
   namespace :customer do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,19 @@
 Rails.application.routes.draw do
 
-  namespace :staff do
+  namespace :staff, path: '' do
     root "top#index"
 
     get "/login" => "sessions#new"
-    resource :session, only: [:create, :destroy]
+    resource :session, only: %i(create destroy)
+    resource :account, except: %i(new create destroy)
   end
 
   namespace :admin do
     root "top#index"
 
     get "/login" => "sessions#new"
-    resource :session, only: [:create, :destroy]
+    resource :session, only: %i(create destroy)
+    resources :staff_members
   end
 
   namespace :customer do

--- a/db/seeds/development/administrators.rb
+++ b/db/seeds/development/administrators.rb
@@ -1,5 +1,3 @@
-require 'faker'
-
 Administrator.create!(
   email: "admin@example.com",
   password: "foobar"

--- a/db/seeds/development/administrators.rb
+++ b/db/seeds/development/administrators.rb
@@ -1,6 +1,6 @@
 require 'faker'
 
 Administrator.create!(
-  email: Faker::Internet.email,
+  email: "admin@example.com",
   password: "foobar"
 )

--- a/db/seeds/development/staff_members.rb
+++ b/db/seeds/development/staff_members.rb
@@ -1,7 +1,7 @@
 require 'faker'
 
 StaffMember.create!(
-  email: Faker::Internet.email,
+  email: "hoge@example.com",
   family_name: "山田",
   given_name: "太郎",
   family_name_kana: "ヤマダ",

--- a/db/seeds/development/staff_members.rb
+++ b/db/seeds/development/staff_members.rb
@@ -1,5 +1,3 @@
-require 'faker'
-
 StaffMember.create!(
   email: "hoge@example.com",
   family_name: "山田",

--- a/spec/routing/host_constrains_spec.rb
+++ b/spec/routing/host_constrains_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ルーティング' do
+  config = Rails.application.config.baukis2
+  context '職員トップページパス(baukis2.example.com)にGETリクエスト' do
+    url = "http://#{config[:staff][:host]}/#{config[:staff][:path]}"
+    it 'OK' do
+      expect(get: url).to route_to(
+        host: config[:staff][:host],
+        controller: 'staff/top',
+        action: 'index'
+      )
+    end
+  end
+
+  context '管理者ログインフォーム(baukis2.example.com)にGETリクエスト' do
+    url = "http://#{config[:admin][:host]}/#{config[:admin][:path]}/login"
+    it 'OK' do
+      expect(get: url).to route_to(
+        host: config[:admin][:host],
+        controller: 'admin/sessions',
+        action: 'new'
+      )
+    end
+  end
+
+  context 'ホスト名をbaukis2.example.com以外にしてリクエスト' do
+    it 'ルーティング対象外' do
+      expect(get: 'http://foo.example.jp').not_to be_routable
+    end
+  end
+
+  context 'baukis2.example.com上の存在しないパスにリクエスト' do
+    it 'ルーティング対象外' do
+      expect(get: "http://#{config[:staff][:host]}/xyz").not_to be_routable
+    end
+  end
+end

--- a/spec/routing/host_constrains_spec.rb
+++ b/spec/routing/host_constrains_spec.rb
@@ -26,6 +26,17 @@ RSpec.describe 'ルーティング' do
     end
   end
 
+  context '顧客トップページパス(example.com)にGETリクエスト' do
+    url = "http://#{config[:customer][:host]}/#{config[:customer][:path]}"
+    it 'OK' do
+      expect(get: url).to route_to(
+        host: config[:customer][:host],
+        controller: 'customer/top',
+        action: 'index'
+      )
+    end
+  end
+
   context 'ホスト名をbaukis2.example.com以外にしてリクエスト' do
     it 'ルーティング対象外' do
       expect(get: 'http://foo.example.jp').not_to be_routable


### PR DESCRIPTION
## パスパラメーター値の制限
```ruby
get 'accounts/:id' => 'accounts#show', constraint: { id: /\d*/ }
```

## ヘルパーメソッドを別名で作る
```ruby
get 'accounts/login' => 'accounts#create', as: :staff_login
```
→ パスヘルパーメソッドはクエリパラメータを付与することができる
staff_login_path(tracking: "001")

## path: URLパスだけを変更する　探索するコントローラーは変化しない
```ruby
namespace :staff, path: 'foo' do
  get 'login' => 'accounts#login'
end
```
→URLパスが`staff/login`から`foo/login`になる

## module: 探索するコントローラーを変更する
```ruby
namespace :staff, module: 'foo' do
    get 'login' => 'accounts#login'
end
```
→処理するコントローラーが`staff/accounts`から、`foo/accounts`になる
→Staff::AccountsからFoo::Accountsになるということ

## as: 生成するパスヘルパーメソッドを変更する
```ruby
namespace :staff, as: 'foo' do
    get 'login' => 'accounts#login'
end
```
→ヘルパーメソッドメソッド名が`:staff_login`から`:foo_login`になる

##  controller: resource単位で探索するコントローラーを変更する URLパスとヘルパーメソッドは変更なし
```ruby
namespace :admin do
    resources :staff_members, controller: 'emplpyees'
end
```
→`admin/staff_members`ではなく、`admin/employees`コントローラーを探索する

##  controller: resourse単位でpathを変更する
```ruby
namespace :admin do
    resources :staff_members, path: 'staff'
end
```
→パスは`admin/staff_members`ではなく、`admin/staff`になる